### PR TITLE
fix: default back to prettier auto-choosing its parser

### DIFF
--- a/codequality/prettier/index.js
+++ b/codequality/prettier/index.js
@@ -9,7 +9,6 @@ module.exports = {
 	bracketSpacing: true,
 	jsxBracketSameLine: false,
 	arrowParens: 'always',
-	parser: 'typescript',
 	overrides: [
 		{
 			files: ['*.json', '.*.json'],


### PR DESCRIPTION
When specifying a parser (and some overrides) in the config, prettier can only handle these defined filetypes. Prettier then tries to prettify all other filetypes i.e. SCSS files using the specified parser. This throws an error because it can't prettify for example SCSS files using the TypeScript parser.

By removing the parser option, prettier defaults back to automatically choosing the right parser based on the filetype of files.
Alternative solution: add SCSS filetype as an override as well.

We probably also can remove all of the overrides in the config. What do you think? I could update this pull request to remove them as well.